### PR TITLE
Mover back to a 2 step installer

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -37,8 +37,9 @@ echo "Starting to install Intercity"
 
 echo "Installed: Intercity CLI (Version ${version})"
 echo
-echo "Please restart your terminal session or to get started right away run:"
-echo " source ${source_file}"
+echo
+echo "To start the installation of your Intercity Instance run:"
+echo "  source ${source_file} && intercity-server install"
 echo
 echo "Run 'intercity-server' to see help"
 echo

--- a/scripts/installer
+++ b/scripts/installer
@@ -32,9 +32,6 @@ mv /tmp/${dir_name} /var/intercity-cli
 
 rm /tmp/${file_name}
 
-echo "Starting to install Intercity"
-/var/intercity-cli/intercity-server install
-
 echo "Installed: Intercity CLI (Version ${version})"
 echo
 echo


### PR DESCRIPTION
Because we are asking for input in the installer, piping the bash script into
bash does not work. This is due to the ways that Ruby handles its $stdin.

We probably can find a way around this in the future, but for now this is the
best solution.
