### PR TITLE
Allow Intercity to run on custom port

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,8 @@ Vagrant.configure(2) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 80, host: 1234
+  config.vm.network "forwarded_port", guest: 880, host: 880
+  config.vm.network "forwarded_port", guest: 8443, host: 8443
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,8 @@ Vagrant.configure(2) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 80, host: 1234
-  config.vm.network "forwarded_port", guest: 880, host: 880
-  config.vm.network "forwarded_port", guest: 8443, host: 8443
+  config.vm.network "forwarded_port", guest: 8880, host: 8880
+  config.vm.network "forwarded_port", guest: 8843, host: 8843
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/lib/intercity_server/installer.rb
+++ b/lib/intercity_server/installer.rb
@@ -36,7 +36,7 @@ module IntercityServer
       cli.choose do |menu|
         menu.prompt = "Do you want to run Intercity on a custom port?\n" \
           "This will allow you to run Intercity and your apps on the same server.\n" \
-          "Intercity will then be reachable on #{@hostname}:#{use_ssl ? "8443" : "880"}."
+          "Intercity will then be reachable on #{@hostname}:#{use_ssl ? "8843" : "8880"}."
         menu.choice(:yes) { @use_custom_port = true }
         menu.choices(:no) { @use_custom_port = false }
       end
@@ -60,7 +60,7 @@ module IntercityServer
       cli.say "---- Done\n\n"
       address = @hostname
       if use_custom_port
-        address = "#{address}:#{use_ssl ? "8443" : "880"}"
+        address = "#{address}:#{use_ssl ? "8843" : "8880"}"
       end
       cli.say "You can reach your brand new Intercity instance on: #{address}."
 
@@ -111,8 +111,8 @@ module IntercityServer
       end
 
       if use_custom_port
-        config_content = config_content.gsub(/80:80/, "880:80")
-        config_content = config_content.gsub(/443:443/, "8443:443")
+        config_content = config_content.gsub(/80:80/, "8880:80")
+        config_content = config_content.gsub(/443:443/, "8843:443")
       end
 
       File.open(config_file, "w") {|file| file.puts config_content }

--- a/lib/intercity_server/installer.rb
+++ b/lib/intercity_server/installer.rb
@@ -35,7 +35,7 @@ module IntercityServer
 
       cli.choose do |menu|
         menu.prompt = "Do you want to run Intercity on a custom port?\n" \
-          "This will allow you to run Intercity and your apps on the same server.\n" \
+          "This allows you to run both the Intercity control panel and deploy your apps on this server.\n" \
           "Intercity will then be reachable on #{@hostname}:#{use_ssl ? "8843" : "8880"}."
         menu.choice(:yes) { @use_custom_port = true }
         menu.choices(:no) { @use_custom_port = false }


### PR DESCRIPTION
There are use cases where you want to have your intercity server and app server
to be the same. This was not possible due to port collision on port 80.

By allowing the user to set the port to 880 (8443 for ssl), they can now have
the above scenario.

Fixes: https://github.com/intercity/intercity-next/issues/187
