### PR TITLE
[hotfix] Set correct version of intercity-server for installer script

### DIFF
--- a/scripts/installer
+++ b/scripts/installer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=0.1.0
+version=0.2.0
 
 dir_name=intercity-server-${version}-linux-x86_64
 file_name=${dir_name}.tar.gz


### PR DESCRIPTION
The current installer script is broken because it tries to download 0.1.0 from the new intercity.io download location. But the version should be 0.2.0. Merging this in right away to not break people's install scripts.
